### PR TITLE
fix(analysis.test.js): interview3_passed

### DIFF
--- a/src/analysis.test.js
+++ b/src/analysis.test.js
@@ -16,7 +16,7 @@ describe(`run simulation`, () => {
     screening_phoneScreenPassed: random.binomial(1, 0.5),
     interview1_passed: random.binomial(1, 0.5),
     interview2_passed: random.binomial(1, 0.3),
-    interview3_passed: random.binomial(1, 0.7),
+    interview3_passed: random.binomial(1, 0.3),
     offer_offerReceivedVersusOthers: random.binomial(1, 0.5),
     offer_isGood: random.binomial(1, 0.8),
     general_positionDisappears: random.binomial(1, 0.05), // will be tested multiple times


### PR DESCRIPTION
This makes interview3_passed the same as interview2_passed.

Whereas earlier, interview3_passed was higher (0.7) than interview2_passed (0.3) which mistakenly(?) suggested that interview round 3 would be easier than interview round 2.